### PR TITLE
Mcruvinel/add docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,57 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.venv/
+venv/
+ENV/
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+tmp/
+temp/
+*.tmp

--- a/.dockerignore
+++ b/.dockerignore
@@ -33,11 +33,6 @@ Thumbs.db
 .gitignore
 .gitattributes
 
-# Documentation
-README.md
-*.md
-docs/
-
 # CI/CD
 .github/
 .gitlab-ci.yml

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ rawcrop-master/
 ```
 
 ## Quick Start
+### Option 1: Docker (Recommended)
+```bash
+docker-compose up --build
+```
+- Frontend: http://localhost:5173
+- Backend: http://localhost:8000
+- API Docs: http://localhost:8000/docs
+
+### Option 2: Manual Setup
 
 ### Backend (FastAPI)
 
@@ -48,6 +57,14 @@ npm run dev
 ```
 
 Open the printed local URL (commonly http://localhost:5173).
+
+## Testing
+```bash
+cd backend
+pip install -r requirements-dev.txt
+pytest -v
+```
+See `backend/tests/README.md` for more details.
 
 ## Configuration
 

--- a/backend/dockerfile
+++ b/backend/dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.11-slim
 
 # Install exiftool and other system tools
-RUN apt-get update && apt-get install -y libimage-exiftool-perl
+RUN apt-get update && apt-get install -y libimage-exiftool-perl && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./backend:/app
+      - /app/.venv
+    environment:
+      - PYTHONUNBUFFERED=1
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    networks:
+      - rawcrop
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "5173:80"
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - rawcrop
+
+networks:
+  rawcrop:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,10 @@ services:
       - "8000:8000"
     volumes:
       - ./backend:/app
-      - /app/.venv
     environment:
       - PYTHONUNBUFFERED=1
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/docs')"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -23,6 +22,8 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        VITE_API_BASE_URL: http://localhost:8000
     ports:
       - "5173:80"
     depends_on:

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,5 +1,7 @@
-# Frontend Dockerfile for RawCrop
 FROM node:20-alpine AS builder
+
+ARG VITE_API_BASE_URL=http://localhost:8000
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 WORKDIR /app
 COPY package*.json ./
@@ -12,6 +14,6 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 80
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
+  CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -1,0 +1,17 @@
+# Frontend Dockerfile for RawCrop
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
This PR updates the README to include a quickstart guide using Docker Compose. It also adds the frontend and backend Dockerfiles to allow running the full RawCrop stack with a single command. Users can now build and start both services without manually setting up Python or Node environments.

## Type of Change
- [ ] Bug fix
- [x] Feature
- [x] Docs
- [ ] Chore

## Screenshots / Demos (if UI)
N/A — documentation and Docker setup only.

## Checklist
- [x] Builds locally (`npm run build` and backend imports)
- [x] No breaking changes
- [x] Updated docs/comments if needed
